### PR TITLE
Updated to support always_pxe and userdata cmd line flags

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -152,7 +152,7 @@ func ListDevice(deviceID string) error {
 }
 
 // CreateDevice creates a new device
-func CreateDevice(projectID, hostname, plan, facility, operatingSystem, billingCycle, userData string, tags []string, spotInstance bool, spotPriceMax float64) error {
+func CreateDevice(projectID, hostname, plan, facility, operatingSystem, billingCycle, alwaysPXE, userData string, tags []string, spotInstance bool, spotPriceMax float64) error {
 	client, err := NewPacketClient()
 	if err != nil {
 		return err
@@ -165,6 +165,7 @@ func CreateDevice(projectID, hostname, plan, facility, operatingSystem, billingC
 		OS:           operatingSystem,
 		BillingCycle: billingCycle,
 		ProjectID:    projectID,
+		AlwaysPXE:    alwaysPXE,
 		UserData:     userData,
 		SpotInstance: spotInstance,
 		SpotPriceMax: spotPriceMax,
@@ -194,6 +195,7 @@ func CreateDeviceVerbose(projectID, hostname, plan, facility, operatingSystem, b
 		OS:           operatingSystem,
 		BillingCycle: billingCycle,
 		ProjectID:    projectID,
+		AlwaysPXE:    alwaysPXE,
 		UserData:     userData,
 		SpotInstance: spotInstance,
 		SpotPriceMax: spotPriceMax,

--- a/cmd/baremetal.go
+++ b/cmd/baremetal.go
@@ -48,6 +48,10 @@ var createDeviceCmd = &cobra.Command{
 		facility := cmd.Flag("facility").Value.String()
 		osType := cmd.Flag("os-type").Value.String()
 		billing := cmd.Flag("billing").Value.String()
+		alwaysPXE := cmd.Flag("always-pxe").Value.Boolean()
+		if alwaysPXE == "" {
+			alwaysPXE := false
+		}
 		userDataFile := cmd.Flag("file").Value.String()
 		if userDataFile != "" {
 			data, err := ioutil.ReadFile(userDataFile)
@@ -56,12 +60,14 @@ var createDeviceCmd = &cobra.Command{
 			}
 			userData = string(data)
 		}
+		// let "--userdata" override "--file"
+		userData := cmd.Flag("userdata").Value.String()
 		// tags := cmd.Flag("tags").Value.String()
 		if silent {
-			err := CreateDevice(projectID, hostname, plan, facility, osType, billing, userData, []string{}, spotInstance, spotPriceMax)
+			err := CreateDevice(projectID, hostname, plan, facility, osType, billing, alwaysPXE, userData, []string{}, spotInstance, spotPriceMax)
 			return err
 		}
-		err := CreateDeviceVerbose(projectID, hostname, plan, facility, osType, billing, userData, []string{}, spotInstance, spotPriceMax)
+		err := CreateDeviceVerbose(projectID, hostname, plan, facility, osType, billing, alwaysPXE, userData, []string{}, spotInstance, spotPriceMax)
 		return err
 	},
 }
@@ -156,7 +162,9 @@ func init() {
 	createDeviceCmd.Flags().String("facility", "", "DC location. Available values are sjc1: Sunnyvale CA, ewr1: Parsippany NJ, ams1: Amsterdam NL, nrt1: Tokyo JP")
 	createDeviceCmd.Flags().String("os-type", "centos_7", "Operating system to deploy to the server.")
 	createDeviceCmd.Flags().String("billing", "hourly", "Choose \"hourly\" or \"monthly\" billing.")
+	createDeviceCmd.Flags().String("always-pxe", false, "Set \"always_pxe\" to \"true\" or \"false\". (default: false)")
 	createDeviceCmd.Flags().StringP("file", "f", "", "Read userdata from a file.")
+	createDeviceCmd.Flags().String("userdata", "", "Set userdata; overrides \"--file\" userdata.")
 	createDeviceCmd.Flags().BoolVarP(&silent, "silent", "s", false, "Omit provisioning logs")
 	createDeviceCmd.Flags().BoolVarP(&spotInstance, "spot-instance", "", false, "Create as a spot instance")
 	createDeviceCmd.Flags().Float64VarP(&spotPriceMax, "spot-price-max", "", 0.0, "Spot market price bid.")


### PR DESCRIPTION
- added `baremetal --always-pxe [true|false]` option
- added `baremetal --userdata "String"` option

Note:  `--userdata` will override the `--file` option.