### PR TITLE
Fix the alwaysPXE options for verbose

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -182,7 +182,7 @@ func CreateDevice(projectID, hostname, plan, facility, operatingSystem, billingC
 }
 
 // CreateDeviceVerbose creates a new device and logs events till the device is provisionned
-func CreateDeviceVerbose(projectID, hostname, plan, facility, operatingSystem, billingCycle, userData string, tags []string, spotInstance bool, spotPriceMax float64) error {
+func CreateDeviceVerbose(projectID, hostname, plan, facility, operatingSystem, billingCycle, alwaysPXE, userData string, tags []string, spotInstance bool, spotPriceMax float64) error {
 	client, err := NewPacketClient()
 	if err != nil {
 		return err

--- a/cmd/baremetal.go
+++ b/cmd/baremetal.go
@@ -49,9 +49,6 @@ var createDeviceCmd = &cobra.Command{
 		osType := cmd.Flag("os-type").Value.String()
 		billing := cmd.Flag("billing").Value.String()
 		alwaysPXE := cmd.Flag("always-pxe").Value.Boolean()
-		if alwaysPXE == "" {
-			alwaysPXE := false
-		}
 		userDataFile := cmd.Flag("file").Value.String()
 		if userDataFile != "" {
 			data, err := ioutil.ReadFile(userDataFile)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/ebsarr/packet/cmd"
+import "github.com/sygibson/packet/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
- missed redundant-ish Verbose function call for alwaysPXE